### PR TITLE
docs: move formalai.lang TODOs to ToDo.md and add model set AL execution spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,3 +174,7 @@ This project enforces strict text handling rules via `.gitattributes`:
 For detailed installation instructions, refer to our [Installation Guide](./docs/installation/readme.md). The guide covers:
 - Setting up Ollama for local LLM support
 - Installing AutoGen (AutoFac) with Ollama integration
+
+## TODO
+
+For TODOs related to the formalai.lang personality, see [personalities/formalai.lang/ToDo.md](personalities/formalai.lang/ToDo.md).

--- a/personalities/formalai.lang/ToDo.md
+++ b/personalities/formalai.lang/ToDo.md
@@ -1,1 +1,3 @@
 Convert to a real schema instead of lark
+
+- Spec out the ability to specify a set of models to run an expression in AL on, until one responds correctly.


### PR DESCRIPTION
- Updated README.md to direct formalai.lang TODOs to personalities/formalai.lang/ToDo.md.
- Added a new TODO to ToDo.md: "Spec out the ability to specify a set of models to run an expression in AL on, until one responds correctly."
- Preserved existing ToDo.md content.
